### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.sample-java-spring-boot-app
+++ b/Dockerfile.sample-java-spring-boot-app
@@ -1,0 +1,11 @@
+FROM maven:3.6.3-jdk-11-slim AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src src
+RUN mvn package -DskipTests
+
+FROM openjdk:11-jre-slim
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO java-test
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: java-test
+
+sample-java-spring-boot-app:
+  defines: runnable
+  metadata:
+    name: sample-java-spring-boot-app
+    description: Java Spring Boot web application
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    sample-java-spring-boot-app:
+      image: env-3371.registry.local/sample-java-spring-boot-app:main-53eedd9
+      build: .
+      dockerfile: Dockerfile.sample-java-spring-boot-app
+  services:
+    http-server:
+      description: Port for HTTP server
+      container: sample-java-spring-boot-app
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - java-test/sample-java-spring-boot-app


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for Java Spring Boot Application

## Changes Made

- **Dockerfile Creation**: I created a new `Dockerfile.sample-java-spring-boot-app` for the Java Spring Boot application. The application's main entry point is `SampleApplication.java`. Initially, the build failed due to the absence of the `.mvn` directory and issues with the Maven wrapper. I resolved this by adjusting the Dockerfile to use a standard Maven installation.
- **Monk Configuration**: I added a `monk.yaml` file to define the Monk.io deployment configuration and a `MANIFEST` file to list all files containing Monk configurations.
- **Service Mapping**: The application does not use a database or any third-party services, and it exposes port 8080 for HTTP traffic. No environment variables or connections to other services are required for this application.

## Deployment Instructions

- **Port Exposure**: Ensure that port 8080 is available for the embedded Tomcat server.
- **Environment**: No specific environment variables are needed for this application.
- **Dependencies**: Make sure all necessary services and configurations are present in the environment where the container will run.

## Next Steps

- **Merge PR**: Once this PR is merged, the application will be re-deployed on each subsequent push.
- **Monitor Application**: After deployment, monitor the application to ensure it is running as expected without any hidden errors.

Please note that the containerization process is complete, and the application is ready for deployment. The service logs confirm that the application starts and runs successfully.