### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.sample-java-application
+++ b/Dockerfile.sample-java-application
@@ -1,0 +1,11 @@
+FROM maven:3.6.3-jdk-8 AS build
+WORKDIR /app
+COPY src /app/src
+COPY pom.xml /app
+RUN mvn clean package
+
+FROM openjdk:8-jdk-alpine
+WORKDIR /app
+COPY --from=build /app/target/sample-0.0.1-SNAPSHOT.jar /app
+EXPOSE 8080
+CMD ["java", "-jar", "sample-0.0.1-SNAPSHOT.jar"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO java-test
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: java-test
+
+sample-java-application:
+  defines: runnable
+  metadata:
+    name: sample-java-application
+    description: A Spring Boot application serving a static website
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    sample-java-application:
+      image: env-4295.registry.local/sample-java-application:main-53eedd9
+      build: .
+      dockerfile: Dockerfile.sample-java-application
+  services:
+    http:
+      description: Port for HTTP server
+      container: sample-java-application
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - java-test/sample-java-application


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for Sample Java Application

## Changes Made

- **Dockerfile Creation**: I've added a `Dockerfile.sample-java-application` to containerize the Maven-based Java application. Initially, the build failed due to a missing `.mvn` directory. I resolved this by modifying the Dockerfile to use the standard Maven installation instead of the Maven wrapper.
- **Monk Configuration**: A `monk.yaml` configuration file has been created and added to the repository along with a `MANIFEST` file to list all Monk configurations.
- **Service Analysis**: The application has been analyzed, and it has been determined that it serves a static website using Spring Boot, without any REST API, service layer, or database integration. The service exposes port 8080 for HTTP traffic.

## Deployment Readiness

- The Dockerfile has been successfully built, and the application starts without any errors. The service logs confirm that the application is running correctly on port 8080.
- No environment variables or connections to other services are required for this application, as per the analysis of the `pom.xml` and `Dockerfile.sample-java-application`.
- The Monk configuration is complete and ready for deployment.

## Instructions for Continuation

- **Merge PR**: The PR can be merged to ensure the application is re-deployed on each subsequent push.
- **No Further Actions Required**: There are no additional configurations or environment variables needed at this stage. The service is ready to be deployed as is.

Please review the changes and proceed with merging if everything is in order. The application should be operational upon deployment.