### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.sample-java-spring-boot-app
+++ b/Dockerfile.sample-java-spring-boot-app
@@ -1,0 +1,14 @@
+FROM maven:3.6.3-jdk-11-slim AS build
+WORKDIR /workspace/app
+
+COPY pom.xml .
+COPY src src
+
+RUN mvn install -DskipTests
+
+FROM openjdk:11-jre-slim
+WORKDIR /app
+COPY --from=build /workspace/app/target/*.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO java-test
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: java-test
+
+sample-java-spring-boot-app:
+  defines: runnable
+  metadata:
+    name: sample-java-spring-boot-app
+    description: A Java Spring Boot web application serving static content.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    sample-java-spring-boot-app:
+      image: env-4016.registry.local/sample-java-spring-boot-app:main-53eedd9
+      build: .
+      dockerfile: Dockerfile.sample-java-spring-boot-app
+  services:
+    http-service:
+      description: HTTP service port
+      container: sample-java-spring-boot-app
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - java-test/sample-java-spring-boot-app


### PR DESCRIPTION
# Containerization and Deployment Configuration for Java Spring Boot Application

## Summary of Changes
I have successfully containerized the Java Spring Boot application and prepared it for deployment. Below are the key changes and additions:

- **Dockerfile Creation**: A Dockerfile has been added to the repository to build a container image for the Java Spring Boot application. Initially, the build process encountered an error due to missing Maven wrapper files. I resolved this by adjusting the Dockerfile to install Maven directly in the image and use it to build the project.
- **Monk.io Configuration**: I added a `monk.yaml` file containing the Monk.io configuration and a `MANIFEST` file listing all files with Monk configurations. This will facilitate the deployment of the application using Monk.io.
- **Service Configuration**: The application does not require any environment variables or connections to other services. It exposes port 8080 for HTTP traffic, as indicated in the Dockerfile.

## Instructions for Deployment
The application is now ready for deployment. To deploy the application, merge this PR, and the application will be re-deployed on each subsequent push. The containerized application can be run in isolation or as part of a larger environment, with environment variables and required services provided at runtime.

## Final Notes
The containerization process is complete, and the application has been confirmed to start successfully within the container. No further action is required unless additional services or environment variables need to be integrated in the future.