### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.sample-java-spring-boot-app
+++ b/Dockerfile.sample-java-spring-boot-app
@@ -1,0 +1,22 @@
+# Use Maven base image to build the project
+FROM maven:3.6.3-jdk-8 AS build
+WORKDIR /app
+
+# Copy the project files to the container
+COPY . .
+
+# Build the project
+RUN mvn clean package -DskipTests
+
+# Use Java 8 base image for the runtime
+FROM openjdk:8-jdk-alpine
+WORKDIR /app
+
+# Copy the built artifact from the build stage
+COPY --from=build /app/target/*.jar app.jar
+
+# Expose the port the application runs on
+EXPOSE 8080
+
+# Run the application
+CMD ["java", "-jar", "app.jar"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO java-test
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: java-test
+
+sample-java-spring-boot-app:
+  defines: runnable
+  metadata:
+    name: sample-java-spring-boot-app
+    description: A Java Spring Boot web application serving static content and templates.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    sample-java-spring-boot-app:
+      image: env-4106.registry.local/sample-java-spring-boot-app:main-53eedd9
+      build: .
+      dockerfile: Dockerfile.sample-java-spring-boot-app
+  services:
+    http:
+      description: HTTP web server
+      container: sample-java-spring-boot-app
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - java-test/sample-java-spring-boot-app


### PR DESCRIPTION
# Containerization and Deployment Configuration for Java Spring Boot Application

## Summary of Changes
I have successfully containerized the Java Spring Boot application and prepared it for deployment with the following changes:

- **Dockerfile Creation**: A Dockerfile has been added to build and run the Java Spring Boot application. It uses a Maven base image to build the application and a Java 8 runtime image to run it. The application listens on port 8080.
- **Monk.io Configuration**: Added `monk.yaml` and `MANIFEST` files to configure the application deployment with Monk. These files are necessary for Monk to understand the deployment setup.

## Deployment Instructions
The application is ready to be re-deployed on each subsequent push. To deploy the application, simply merge this PR. The application is a standalone service that serves static content and templates, and it does not require any external services or environment variables.

## Notes on Containerization Process
- No external services like databases are configured for the application, as indicated by the empty 'application.properties' file.
- No environment variables were identified for the 'sample-java-spring-boot-app' service after thorough analysis.
- The service is a standalone application that exposes port 8080 for HTTP traffic.
- The container logs confirmed that the Spring Boot application started successfully, and the Tomcat server is running on port 8080. There were no error messages, indicating that the Dockerfile is correctly configured.

Please review the changes and proceed with the merge to deploy the application.